### PR TITLE
fix: initial window doesn't render until resize (macOS / iOS)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -69,6 +69,8 @@ impl ApplicationHandler<Graphics> for App {
     }
 
     fn user_event(&mut self, _event_loop: &ActiveEventLoop, graphics: Graphics) {
+        // Request a redraw now that graphics are ready
+        graphics.request_redraw();
         self.state = State::Ready(graphics);
     }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -109,6 +109,10 @@ pub struct Graphics {
 }
 
 impl Graphics {
+    pub fn request_redraw(&self) {
+        self.window.request_redraw();
+    }
+
     pub fn resize(&mut self, new_size: PhysicalSize<u32>) {
         self.surface_config.width = new_size.width.max(1);
         self.surface_config.height = new_size.height.max(1);


### PR DESCRIPTION
Hi! thanks for the template, really cool. The only issue is that nothing is rendered upon initial launch, until I resize the window. It was reproduced on macOS / iPhone / iPad and this patch will fix it for all these platforms as well. I hope it helps!